### PR TITLE
Only filter out non-arm64 archives when version above 3.0.0/2.12.0-4.1.pre

### DIFF
--- a/fvm.sh
+++ b/fvm.sh
@@ -360,7 +360,7 @@ fvm_install(){
   local FVM_ARCH="$(fvm_get_arch)"
   local RELEASES
   RELEASES="$(fvm_releases "_${PROVIDED_VERSION}-")"
-  if [ "_${FVM_OS}" = "_macos" ] && [ "_${FVM_ARCH}" = "_arm64" ] && fvm_version_greater_than_or_equal_to "2.12.0"; then
+  if [ "_${FVM_OS}" = "_macos" ] && [ "_${FVM_ARCH}" = "_arm64" ] && fvm_version_greater_than_or_equal_to "${PROVIDED_VERSION}" "2.12.0"; then
     RELEASES="$(fvm_echo "${RELEASES}" | fvm_grep "arm64")"
   else
     RELEASES="$(fvm_echo "${RELEASES}" | fvm_grep -v "arm64")"


### PR DESCRIPTION
This resolves #5 

After this pr is merged,

- `fvm ls-remote` will not filter out non-arm64 archive versions under 3.3.0/2.12.0-4.1.pre
- `fvm install <version>` will allow to install version under 3.3.0/2.12.0-4.1.pre on macOS M1 chip.
